### PR TITLE
fix value keyword and assert_rel_error deprecations

### DIFF
--- a/CADRE/test/test_CADRE_derivs.py
+++ b/CADRE/test/test_CADRE_derivs.py
@@ -8,7 +8,7 @@ import unittest
 import numpy as np
 
 from openmdao.api import Problem
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 from CADRE.CADRE_group import CADRE
 
@@ -71,7 +71,7 @@ class TestCADRE(unittest.TestCase):
                     print(np.nonzero(Jn))
                     print(np.nonzero(Jf))
                 diff = abs(Jf - Jn)
-                assert_rel_error(self, diff.max(), 0.0, 1e-4)
+                assert_near_equal(diff.max(), 0.0, 1e-4)
 
 
 if __name__ == '__main__':

--- a/CADRE/test/test_derivatives.py
+++ b/CADRE/test/test_derivatives.py
@@ -8,7 +8,7 @@ import unittest
 import numpy as np
 
 from openmdao.api import Problem, IndepVarComp
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 from CADRE.attitude import Attitude_Angular, Attitude_AngularRates, \
     Attitude_Attitude, Attitude_Roll, Attitude_RotationMtx, \
@@ -56,7 +56,7 @@ class TestCADRE(unittest.TestCase):
         # create independent vars for each input, initialized with random values
         indep = IndepVarComp()
         for item in inputs + state0:
-            shape = self.inputs_dict[item]['value'].shape
+            shape = self.inputs_dict[item]['val'].shape
             units = self.inputs_dict[item]['units']
             indep.add_output(item, np.random.random(shape), units=units)
 
@@ -79,7 +79,7 @@ class TestCADRE(unittest.TestCase):
                     diff = np.nan_to_num(abs(Jf - Jn) / Jn)
                 else:
                     diff = abs(Jf - Jn)
-                assert_rel_error(self, diff.max(), 0.0, 1e-3)
+                assert_near_equal(diff.max(), 0.0, 1e-3)
 
         # check partials
         # FIXME: several components fail check_partials
@@ -252,9 +252,9 @@ class TestCADRE(unittest.TestCase):
         self.setup(compname, inputs, state0)
 
         # These need to be a certain magnitude so it doesn't blow up
-        shape = self.inputs_dict['P_comm']['value'].shape
+        shape = self.inputs_dict['P_comm']['val'].shape
         self.prob['P_comm'] = np.ones(shape)
-        shape = self.inputs_dict['GSdist']['value'].shape
+        shape = self.inputs_dict['GSdist']['val'].shape
         self.prob['GSdist'] = np.random.random(shape) * 1e3
 
         self.prob.run_model()
@@ -404,13 +404,13 @@ class TestCADRE(unittest.TestCase):
 
         self.setup(compname, inputs, state0)
 
-        shape = self.inputs_dict['temperature']['value'].shape
+        shape = self.inputs_dict['temperature']['val'].shape
         self.prob['temperature'] = np.random.random(shape) * 40 + 240
 
-        shape = self.inputs_dict['exposedArea']['value'].shape
+        shape = self.inputs_dict['exposedArea']['val'].shape
         self.prob['exposedArea'] = np.random.random(shape) * 1e-4
 
-        shape = self.inputs_dict['Isetpt']['value'].shape
+        shape = self.inputs_dict['Isetpt']['val'].shape
         self.prob['Isetpt'] = np.random.random(shape) * 1e-2
 
         self.prob.run_model()
@@ -483,9 +483,9 @@ class TestCADRE(unittest.TestCase):
         self.setup(compname, inputs, state0)
         self.prob.model.comp.h = 0.01
 
-        shape = self.inputs_dict['w_B']['value'].shape
+        shape = self.inputs_dict['w_B']['val'].shape
         self.prob['w_B'] = np.random.random(shape) * 1e-4
-        shape = self.inputs_dict['T_RW']['value'].shape
+        shape = self.inputs_dict['T_RW']['val'].shape
         self.prob['T_RW'] = np.random.random(shape) * 1e-9
 
         self.prob.run_model()

--- a/CADRE/test/test_rk_deriv.py
+++ b/CADRE/test/test_rk_deriv.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 
 from openmdao.api import Problem, IndepVarComp
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 from CADRE.rk4 import RK4
 
@@ -139,7 +139,7 @@ class TestCADRE(unittest.TestCase):
                 Jn = J[outp, inp]['J_fd']
                 Jf = J[outp, inp]['J_fwd']
                 diff = abs(Jf - Jn)
-                assert_rel_error(self, diff.max(), 0.0, 6e-5)
+                assert_near_equal(diff.max(), 0.0, 6e-5)
 
 
 if __name__ == '__main__':

--- a/benchmark/benchmark_derivs_full.py
+++ b/benchmark/benchmark_derivs_full.py
@@ -8,7 +8,7 @@ import unittest
 import numpy as np
 
 from openmdao.api import Problem, LinearBlockGS
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 from CADRE.CADRE_mdp import CADRE_MDP_Group
 
@@ -69,7 +69,7 @@ class BenchmarkDerivsSerial(unittest.TestCase):
         # ----------------------------------------
         J = prob.compute_totals()
 
-        assert_rel_error(self, J['obj.val', 'bp.antAngle'][0][0],
+        assert_near_equal(J['obj.val', 'bp.antAngle'][0][0],
                          67.15777407, 1e-4)
-        assert_rel_error(self, J['obj.val', 'parallel.pt1.design.CP_gamma'][-1][-1],
+        assert_near_equal(J['obj.val', 'parallel.pt1.design.CP_gamma'][-1][-1],
                          -0.62410223816776056, 1e-4)

--- a/benchmark/benchmark_derivs_full_par.py
+++ b/benchmark/benchmark_derivs_full_par.py
@@ -8,7 +8,7 @@ import unittest
 import numpy as np
 
 from openmdao.api import Problem, LinearBlockGS
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 from CADRE.CADRE_mdp import CADRE_MDP_Group
 
@@ -71,7 +71,7 @@ class BenchmarkDerivsParallel(unittest.TestCase):
         # ----------------------------------------
         J = prob.compute_totals()
 
-        assert_rel_error(self, J['obj.val', 'bp.antAngle'][0][0],
+        assert_near_equal(J['obj.val', 'bp.antAngle'][0][0],
                          67.15777407, 1e-4)
-        assert_rel_error(self, J['obj.val', 'parallel.pt1.design.CP_gamma'][-1][-1],
+        assert_near_equal(J['obj.val', 'parallel.pt1.design.CP_gamma'][-1][-1],
                          -0.62410223816776056, 1e-4)

--- a/benchmark/benchmark_exec_full.py
+++ b/benchmark/benchmark_exec_full.py
@@ -8,7 +8,7 @@ import unittest
 import numpy as np
 
 from openmdao.api import Problem
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 from CADRE.CADRE_mdp import CADRE_MDP_Group
 
@@ -56,4 +56,4 @@ class BenchmarkExecSerial(unittest.TestCase):
         # ----------------------------------------
         prob.run_driver()
 
-        assert_rel_error(self, prob['obj.val'], -393.789941398, 1.0e-4)
+        assert_near_equal(prob['obj.val'], -393.789941398, 1.0e-4)

--- a/benchmark/benchmark_mppt.py
+++ b/benchmark/benchmark_mppt.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from openmdao.api import Problem, Group, ParallelGroup, ExplicitComponent, IndepVarComp, \
     pyOptSparseDriver
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 from CADRE.power import Power_SolarPower, Power_CellVoltage
 from CADRE.parameters import BsplineParameters
@@ -141,5 +141,4 @@ class BenchmarkMPPT(unittest.TestCase):
 
         # NOTE: adjusting tolerance from 1e-6 to 1e-5 because the answer is slightly
         #       different when running with Python 3.x and the latest numpy/scipy
-        assert_rel_error(self, prob['perf.result'], -9.4308562238E+03, 1e-5)
-
+        assert_near_equal(prob['perf.result'], -9.4308562238E+03, 1e-5)


### PR DESCRIPTION
fix deprecations
- the `value` keyword has been replaced by `val`
- the `assert_rel_error` function has been replaced by `assert_near_equal`