### PR TITLE
Update README and test/coverage badges.

### DIFF
--- a/.github/workflows/CADRE_test_workflow.yml
+++ b/.github/workflows/CADRE_test_workflow.yml
@@ -103,7 +103,7 @@ jobs:
           echo "============================================================="
           echo "Submit coverage"
           echo "============================================================="
-          copy $HOME\.coverage .
+          cd $HOME
           python -m pip install coveralls
           $SITE_DIR=python -c "import site; print(site.getsitepackages()[-1].replace('lib\\site-', 'Lib\\site-'))"
           coveralls --basedir $SITE_DIR

--- a/.github/workflows/CADRE_test_workflow.yml
+++ b/.github/workflows/CADRE_test_workflow.yml
@@ -105,7 +105,7 @@ jobs:
           echo "============================================================="
           cd $HOME
           python -m pip install coveralls
-          $SITE_DIR=python -c "import site; print(site.getsitepackages()[-1].replace('lib\\site-', 'Lib\\site-'))"
+          SITE_DIR=`python -c 'import site; print(site.getsitepackages()[-1])'`
           coveralls --basedir $SITE_DIR
 
   coveralls:

--- a/.github/workflows/CADRE_test_workflow.yml
+++ b/.github/workflows/CADRE_test_workflow.yml
@@ -92,4 +92,28 @@ jobs:
           echo "Run tests (from directory other than repo root)"
           echo "============================================================="
           cd $HOME
-          testflo -n 1 CADRE --timeout=120 --show_skipped
+          testflo -n 1 CADRE --timeout=120 --show_skipped --coverage  --coverpkg CADRE
+
+      - name: Submit coverage
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_SERVICE_NAME: "github"
+          COVERALLS_PARALLEL: true
+        run: |
+          echo "============================================================="
+          echo "Submit coverage"
+          echo "============================================================="
+          copy $HOME\.coverage .
+          python -m pip install coveralls
+          $SITE_DIR=python -c "import site; print(site.getsitepackages()[-1].replace('lib\\site-', 'Lib\\site-'))"
+          coveralls --basedir $SITE_DIR
+
+  coveralls:
+    name: Finish coverage
+    needs: [CADRE_tests]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        parallel-finished: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-
-[![Build Status](https://travis-ci.org/OpenMDAO/CADRE.svg?branch=master)](https://travis-ci.org/OpenMDAO/CADRE)   [![Coverage Status](https://coveralls.io/repos/github/OpenMDAO/CADRE/badge.svg?branch=master)](https://coveralls.io/github/OpenMDAO/CADRE?branch=master)
-
+[![GitHub Actions Test Badge][1]][2]
+[![Coveralls Badge][3]][4]
 
 CADRE CubeSat design problem
 ----------------------------
@@ -26,3 +25,8 @@ And for parallel execution you will need petsc4py:
 
   `pip install petsc4py`
 
+[1]: https://github.com/OpenMDAO/CADRE/actions/workflows/CADRE_test_workflow.yml/badge.svg "Github Actions Badge"
+[2]: https://github.com/OpenMDAO/CADRE/actions "Github Actions"
+
+[3]: https://coveralls.io/repos/github/OpenMDAO/CADRE/badge.svg?branch=master "Coverage Badge"
+[4]: https://coveralls.io/github/OpenMDAO/CADRE?branch=master "CADRE @Coveralls"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 CADRE CubeSat design problem
 ----------------------------
 
-This is an implementation of the CADRE CubeSat problem for OpenMDAO 2.x/3.x.
+This is an implementation of the CADRE CubeSat problem for OpenMDAO 3.x.
 
 It is no longer in active development.
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 CADRE CubeSat design problem
 ----------------------------
 
-This is the implementation for OpenMDAO 2.x. It is currently a work in progress.
+This is an implementation of the CADRE CubeSat problem for OpenMDAO 2.x/3.x.
 
+It is no lopnger in active development.
 
 Instructions for the latest development version:
 
@@ -15,11 +16,9 @@ Instructions for the latest development version:
 
   `pip install -e .`
 
-
 You will also need MBI:
 
   `pip install git+https://github.com/OpenMDAO/MBI`
-
 
 And for parallel execution you will need petsc4py:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CADRE CubeSat design problem
 
 This is an implementation of the CADRE CubeSat problem for OpenMDAO 2.x/3.x.
 
-It is no lopnger in active development.
+It is no longer in active development.
 
 Instructions for the latest development version:
 


### PR DESCRIPTION
- updated README to say CADRE runs with OpenMDAO 3.x (not 2.x)
- replaced old Travis-CI badge with GitHub Actions badge
- added coverage to GitHub workflow and updated badge