### PR TITLE
Fixed test for change of jacobian keys in OpenMDAO 3.31

### DIFF
--- a/.github/workflows/CADRE_test_workflow.yml
+++ b/.github/workflows/CADRE_test_workflow.yml
@@ -40,14 +40,14 @@ jobs:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3
+          python-version: 3.11
           conda-version: "*"
           channels: conda-forge,defaults
           channel-priority: true
 
       - name: Create Environment
         run: |
-          conda install numpy scipy -q -y
+          conda install numpy=1.23 scipy -q -y
 
           python -m pip install --upgrade pip
 


### PR DESCRIPTION
As of OpenMDAO 3.31.0, the keys in the jacobian are the 'user facing' names given to the design vars and responses, rather than the absolute names that were used previously.

This test is comparing the computed jacobian to one that was saved to a pickle with an earlier version of OpenMDAO, so the old keys need to be translated to the new keys.