### PR TITLE
Specify mode for tests that check derivatives

### DIFF
--- a/CADRE/test/test_derivatives.py
+++ b/CADRE/test/test_derivatives.py
@@ -66,7 +66,7 @@ class TestCADRE(unittest.TestCase):
         self.prob.model.add_subsystem('indep', indep, promotes=['*'])
         self.prob.model.add_subsystem('comp', comp, promotes=['*'])
 
-        self.prob.setup()
+        self.prob.setup(mode='fwd')
 
     def compare_derivatives(self, var_in, var_out, rel_error=False):
         # check totals

--- a/CADRE/test/test_rk_deriv.py
+++ b/CADRE/test/test_rk_deriv.py
@@ -121,7 +121,7 @@ class TestCADRE(unittest.TestCase):
         prob.model.add_subsystem('indeps', indeps, promotes=['*'])
         prob.model.add_subsystem('rktest', rktest, promotes=['*'])
 
-        prob.setup()
+        prob.setup(mode='fwd')
         prob.run_model()
 
         # check partials


### PR DESCRIPTION
As of https://github.com/OpenMDAO/OpenMDAO/pull/3142, the optimal deriv direction (assuming the user doesn't specify mode manually) is now determined separately for the driver and for any `compute_totals` calls that don't use the driver's design vars and responses as `of` and `wrt`. (The optimal direction is determined by the relative sizes of the ofs vs the wrts.  If ofs are smaller, fwd mode is used, else rev mode.)

Since these tests don't invoke a Driver, we specify the direction as `fwd` during `setup` so we get the expected keys from `check_totals`.