### PR TITLE
fixed calls to compute_jacvec_product before some attributes were defined

### DIFF
--- a/CADRE/attitude.py
+++ b/CADRE/attitude.py
@@ -51,7 +51,7 @@ class Attitude_Angular(ExplicitComponent):
             w_B[1, i] = np.dot(Odot_BI[0, :, i], O_BI[2, :, i])
             w_B[2, i] = np.dot(Odot_BI[1, :, i], O_BI[0, :, i])
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -72,6 +72,7 @@ class Attitude_Angular(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dw_B = d_outputs['w_B']
 
         if mode == 'fwd':
@@ -235,7 +236,7 @@ class Attitude_Attitude(ExplicitComponent):
             O_RI[1, :, i] = jB
             O_RI[2, :, i] = -v
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -302,6 +303,7 @@ class Attitude_Attitude(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dO_RI = d_outputs['O_RI']
 
         if mode == 'fwd':
@@ -357,7 +359,7 @@ class Attitude_Roll(ExplicitComponent):
         O_BR[1, 1, :] = O_BR[0, 0, :]
         O_BR[2, 2, :] = np.ones(self.n)
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -373,6 +375,7 @@ class Attitude_Roll(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dO_BR = d_outputs['O_BR']
 
         if mode == 'fwd':
@@ -563,7 +566,7 @@ class Attitude_Sideslip(ExplicitComponent):
 
         v_e2b_B[:] = computepositionrotd(self.n, r_e2b_I[3:, :], O_BI)
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -578,6 +581,7 @@ class Attitude_Sideslip(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dv_e2b_B = d_outputs['v_e2b_B']
 
         if mode == 'fwd':
@@ -665,7 +669,7 @@ class Attitude_Torque(ExplicitComponent):
             T_tot[:, i] = np.dot(self.J, wdot_B[:, i]) + \
                 np.dot(wx, np.dot(self.J, w_B[:, i]))
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -690,6 +694,7 @@ class Attitude_Torque(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dT_tot = d_outputs['T_tot']
 
         if mode == 'fwd':

--- a/CADRE/battery.py
+++ b/CADRE/battery.py
@@ -161,7 +161,7 @@ class BatteryPower(ExplicitComponent):
 
         outputs['I_bat'] = P_bat / self.V
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -183,7 +183,7 @@ class BatteryPower(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
-
+        self._compute_partials(inputs)
         dI_bat = d_outputs['I_bat']
 
         if mode == 'fwd':
@@ -257,7 +257,7 @@ class BatteryConstraints(ExplicitComponent):
         outputs['ConS0'] = KSfunction.compute(self.SOC0 - SOC, self.rho).flatten()
         outputs['ConS1'] = KSfunction.compute(SOC - self.SOC1, self.rho).flatten()
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -280,8 +280,9 @@ class BatteryConstraints(ExplicitComponent):
 
     def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
         """
-         Matrix-vector product with the Jacobian.
-         """
+        Matrix-vector product with the Jacobian.
+        """
+        self._compute_partials(inputs)
         if mode == 'fwd':
             if 'I_bat' in d_inputs:
                 if 'ConCh' in d_outputs:

--- a/CADRE/comm.py
+++ b/CADRE/comm.py
@@ -97,7 +97,7 @@ class Comm_AntRotation(ExplicitComponent):
         q_A[2, :] = - np.sin(antAngle/2.) / rt2
         q_A[3, :] = 0.0
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -114,6 +114,7 @@ class Comm_AntRotation(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         if mode == 'fwd':
             if 'antAngle' in d_inputs:
                 for k in range(4):
@@ -169,7 +170,7 @@ class Comm_AntRotationMtx(ExplicitComponent):
 
             O_AB[:, :, i] = np.dot(A.T, B)
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -241,6 +242,7 @@ class Comm_AntRotationMtx(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         if 'q_A' in d_inputs:
             dq_A = d_inputs['q_A']
             dO_AB = d_outputs['O_AB']
@@ -315,7 +317,7 @@ class Comm_BitRate(ExplicitComponent):
             Dr[i] = self.alpha * P_comm[i] * gain[i] * \
                 CommLOS[i] / S2 ** 2
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -350,6 +352,7 @@ class Comm_BitRate(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dDr = d_outputs['Dr']
 
         if mode == 'fwd':
@@ -402,7 +405,7 @@ class Comm_Distance(ExplicitComponent):
         for i in range(0, self.n):
             GSdist[i] = np.dot(r_b2g_A[:, i], r_b2g_A[:, i])**0.5
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -420,6 +423,7 @@ class Comm_Distance(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         if mode == 'fwd':
             if 'r_b2g_A' in d_inputs:
                 for k in range(3):
@@ -462,7 +466,7 @@ class Comm_EarthsSpin(ExplicitComponent):
         q_E[0, :] = np.cos(theta)
         q_E[3, :] = -np.sin(theta)
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -481,6 +485,7 @@ class Comm_EarthsSpin(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         if mode == 'fwd':
             if 't' in d_inputs:
                 for k in range(4):
@@ -534,7 +539,7 @@ class Comm_EarthsSpinMtx(ExplicitComponent):
 
             O_IE[:, :, i] = np.dot(A.T, B)
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -609,6 +614,7 @@ class Comm_EarthsSpinMtx(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         if 'q_E' in d_inputs:
             dO_IE = d_outputs['O_IE']
             dq_E = d_inputs['q_E']
@@ -676,7 +682,7 @@ class Comm_GainPattern(ExplicitComponent):
         self.x[:, 1] = result[1]
         outputs['gain'] = self.MBI.evaluate(self.x)[:, 0]
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -687,6 +693,7 @@ class Comm_GainPattern(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dgain = d_outputs['gain']
 
         if mode == 'fwd':
@@ -745,7 +752,7 @@ class Comm_GSposEarth(ExplicitComponent):
         r_e2g_E[1, :] = r_GS * cos_lat * np.sin(self.d2r*lon)
         r_e2g_E[2, :] = r_GS * np.sin(self.d2r*lat)
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -780,6 +787,7 @@ class Comm_GSposEarth(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dr_e2g_E = d_outputs['r_e2g_E']
 
         if mode == 'fwd':
@@ -838,7 +846,7 @@ class Comm_GSposECI(ExplicitComponent):
         for i in range(0, self.n):
             r_e2g_I[:, i] = np.dot(O_IE[:, :, i], r_e2g_E[:, i])
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -857,6 +865,7 @@ class Comm_GSposECI(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dr_e2g_I = d_outputs['r_e2g_I']
 
         if mode == 'fwd':
@@ -932,7 +941,7 @@ class Comm_LOS(ExplicitComponent):
                 x = (proj - 0) / (-Rb - 0)
                 CommLOS[i] = 3 * x ** 2 - 2 * x ** 3
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -967,6 +976,7 @@ class Comm_LOS(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dCommLOS = d_outputs['CommLOS']
 
         if mode == 'fwd':
@@ -1016,7 +1026,7 @@ class Comm_VectorAnt(ExplicitComponent):
         outputs['r_b2g_A'] = computepositionrotd(self.n, inputs['r_b2g_B'],
                                                  inputs['O_AB'])
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -1027,6 +1037,7 @@ class Comm_VectorAnt(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dr_b2g_A = d_outputs['r_b2g_A']
 
         if mode == 'fwd':
@@ -1090,7 +1101,7 @@ class Comm_VectorBody(ExplicitComponent):
         for i in range(0, self.n):
             r_b2g_B[:, i] = np.dot(O_BI[:, :, i], r_b2g_I[:, i])
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -1109,6 +1120,7 @@ class Comm_VectorBody(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dr_b2g_B = d_outputs['r_b2g_B']
 
         if mode == 'fwd':
@@ -1222,7 +1234,7 @@ class Comm_VectorSpherical(ExplicitComponent):
         outputs['azimuthGS'] = azimuthGS
         outputs['elevationGS'] = elevationGS
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -1240,6 +1252,7 @@ class Comm_VectorSpherical(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         if mode == 'fwd':
             if 'r_b2g_A' in d_inputs:
                 r_b2g_A = d_inputs['r_b2g_A'].reshape((3 * self.n), order='F')

--- a/CADRE/power.py
+++ b/CADRE/power.py
@@ -90,7 +90,7 @@ class Power_CellVoltage(ExplicitComponent):
         for c in range(7):
             outputs['V_sol'] += self.raw[:, c, :].T
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -120,6 +120,7 @@ class Power_CellVoltage(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dV_sol = d_outputs['V_sol']
 
         if mode == 'fwd':

--- a/CADRE/reactionwheel.py
+++ b/CADRE/reactionwheel.py
@@ -57,7 +57,7 @@ class ReactionWheel_Motor(ExplicitComponent):
 
             T_m[:, i] = -T_RW[:, i] - np.dot(w_Bx, h_RW[:, i])
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -98,6 +98,7 @@ class ReactionWheel_Motor(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dT_m = d_outputs['T_m']
 
         if mode == 'fwd':
@@ -165,7 +166,7 @@ class ReactionWheel_Power(ExplicitComponent):
                               self.b * T_RW[k, i])**2 +
                               self.V * self.I0)
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -184,6 +185,7 @@ class ReactionWheel_Power(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dP_RW = d_outputs['P_RW']
 
         if mode == 'fwd':

--- a/CADRE/rk4.py
+++ b/CADRE/rk4.py
@@ -194,7 +194,7 @@ class RK4(ExplicitComponent):
         state_var_name = self.name_map['y']
         outputs[state_var_name][:] = self.y.T.reshape((n_time, n_state)).T
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -255,6 +255,7 @@ class RK4(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials()
         if mode == 'fwd':
             result_ext = self._applyJext(d_inputs, d_outputs)
 

--- a/CADRE/solar.py
+++ b/CADRE/solar.py
@@ -121,7 +121,7 @@ class Solar_ExposedArea(ExplicitComponent):
         self.x[:, 1] = result[0]
         self.x[:, 2] = result[1]
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -133,6 +133,7 @@ class Solar_ExposedArea(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials()
         deA = d_outputs['exposedArea']
 
         if mode == 'fwd':

--- a/CADRE/sun.py
+++ b/CADRE/sun.py
@@ -66,7 +66,7 @@ class Sun_LOS(ExplicitComponent):
                 x = (dist - self.r1) / (self.r2 - self.r1)
                 LOS[i] = 3*x**2 - 2*x**3
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -143,6 +143,7 @@ class Sun_LOS(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dLOS = d_outputs['LOS']
 
         if mode == 'fwd':
@@ -203,7 +204,7 @@ class Sun_PositionBody(ExplicitComponent):
         outputs['r_e2s_B'] = computepositionrotd(self.n, inputs['r_e2s_I'],
                                                  inputs['O_BI'])
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -214,6 +215,7 @@ class Sun_PositionBody(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dr_e2s_B = d_outputs['r_e2s_B']
 
         if mode == 'fwd':
@@ -285,7 +287,7 @@ class Sun_PositionECI(ExplicitComponent):
             r_e2s_I[1, i] = np.sin(Lambda)*np.cos(eps)
             r_e2s_I[2, i] = np.sin(Lambda)*np.sin(eps)
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -321,6 +323,7 @@ class Sun_PositionECI(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         dr_e2s_I = d_outputs['r_e2s_I']
 
         if mode == 'fwd':
@@ -372,7 +375,7 @@ class Sun_PositionSpherical(ExplicitComponent):
         outputs['azimuth'] = azimuth
         outputs['elevation'] = elevation
 
-    def compute_partials(self, inputs, partials):
+    def _compute_partials(self, inputs):
         """
         Calculate and save derivatives. (i.e., Jacobian)
         """
@@ -389,6 +392,7 @@ class Sun_PositionSpherical(ExplicitComponent):
         """
         Matrix-vector product with the Jacobian.
         """
+        self._compute_partials(inputs)
         if mode == 'fwd':
             if 'r_e2s_B' in d_inputs:
                 r_e2s_B = d_inputs['r_e2s_B'].reshape((3*self.n), order='F')


### PR DESCRIPTION
This code wasn't following the OpenMDAO API correctly.  There were a bunch of explicit components that defined both compute_partials and compute_jacvec_product, and compute_partials wasn't updating the partials that were passed in.  It was just computing some internal stuff that was used later in compute_jacvec_product, so I just renamed all of the compute_partials to _compute_partials and called them at the beginning of compute_jacvec_product.