### PR TITLE
Gave CADRE an ExplicitComponent class that behaves like OpenMDAO used to

### DIFF
--- a/CADRE/attitude.py
+++ b/CADRE/attitude.py
@@ -5,7 +5,7 @@ Attitude discipline for CADRE.
 from six.moves import range
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+from CADRE.explicit import ExplicitComponent
 
 from CADRE.kinematics import computepositionrotd, computepositionrotdjacobian
 

--- a/CADRE/battery.py
+++ b/CADRE/battery.py
@@ -4,7 +4,7 @@ Battery discipline for CADRE
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+from CADRE.explicit import ExplicitComponent
 from openmdao.components.ks_comp import KSfunction
 
 from CADRE import rk4

--- a/CADRE/comm.py
+++ b/CADRE/comm.py
@@ -9,7 +9,7 @@ import numpy as np
 import scipy.sparse
 from MBI import MBI
 
-from openmdao.core.explicitcomponent import ExplicitComponent
+from CADRE.explicit import ExplicitComponent
 
 from CADRE.kinematics import fixangles, computepositionspherical, \
     computepositionsphericaljacobian, computepositionrotd,\

--- a/CADRE/explicit.py
+++ b/CADRE/explicit.py
@@ -1,0 +1,23 @@
+
+from openmdao.core.explicitcomponent import ExplicitComponent as om_ExplicitComponent
+
+class ExplicitComponent(om_ExplicitComponent):
+    # override _linearize to get the old OpenMDAO behavior where a component could have
+    # matrix free and jacobian methods.
+    def _linearize(self, jac=None, sub_do_ln=False):
+        """
+        Compute jacobian / factorization. The model is assumed to be in a scaled state.
+
+        Parameters
+        ----------
+        jac : Jacobian or None
+            Ignored.
+        sub_do_ln : bool
+            Flag indicating if the children should call linearize on their linear solvers.
+        """
+        save = self.matrix_free
+        self.matrix_free = False
+        try:
+            super()._linearize(jac, sub_do_ln)
+        finally:
+            self.matrix_free = save

--- a/CADRE/orbit.py
+++ b/CADRE/orbit.py
@@ -6,7 +6,7 @@ from math import sqrt
 from six.moves import range
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+from CADRE.explicit import ExplicitComponent
 
 from CADRE import rk4
 

--- a/CADRE/parameters.py
+++ b/CADRE/parameters.py
@@ -5,7 +5,7 @@ Bspline module for CADRE
 from six.moves import range
 import numpy as np
 
-from openmdao.core.explicitcomponent import ExplicitComponent
+from CADRE.explicit import ExplicitComponent
 
 from MBI import MBI
 

--- a/CADRE/power.py
+++ b/CADRE/power.py
@@ -7,7 +7,7 @@ from six.moves import range
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+from CADRE.explicit import ExplicitComponent
 
 from MBI import MBI
 

--- a/CADRE/reactionwheel.py
+++ b/CADRE/reactionwheel.py
@@ -5,7 +5,7 @@ Reaction wheel discipline for CADRE
 from six.moves import range
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+from CADRE.explicit import ExplicitComponent
 
 from CADRE import rk4
 

--- a/CADRE/rk4.py
+++ b/CADRE/rk4.py
@@ -7,7 +7,7 @@ from six.moves import range
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+from CADRE.explicit import ExplicitComponent
 
 
 class RK4(ExplicitComponent):

--- a/CADRE/solar.py
+++ b/CADRE/solar.py
@@ -6,7 +6,7 @@ import os
 from six.moves import range
 import numpy as np
 
-from openmdao.core.explicitcomponent import ExplicitComponent
+from CADRE.explicit import ExplicitComponent
 
 from CADRE.kinematics import fixangles
 from MBI import MBI

--- a/CADRE/sun.py
+++ b/CADRE/sun.py
@@ -6,7 +6,7 @@ from six.moves import range
 import numpy as np
 import scipy.sparse
 
-from openmdao.core.explicitcomponent import ExplicitComponent
+from CADRE.explicit import ExplicitComponent
 
 from CADRE.kinematics import computepositionrotd, computepositionrotdjacobian
 from CADRE.kinematics import computepositionspherical, computepositionsphericaljacobian

--- a/CADRE/test/test_rk_deriv.py
+++ b/CADRE/test/test_rk_deriv.py
@@ -124,10 +124,6 @@ class TestCADRE(unittest.TestCase):
         prob.setup(mode='fwd')
         prob.run_model()
 
-        # check partials
-        partials = prob.check_partials(out_stream=None)
-        assert_check_partials(partials, atol=6e-5, rtol=6e-5)
-
         # check totals
         inputs = ['yi', 'yv', 'x0']
         outputs = ['x']
@@ -140,6 +136,10 @@ class TestCADRE(unittest.TestCase):
                 Jf = J[outp, inp]['J_fwd']
                 diff = abs(Jf - Jn)
                 assert_near_equal(diff.max(), 0.0, 6e-5)
+
+        # check partials
+        partials = prob.check_partials(out_stream=None)
+        assert_check_partials(partials, atol=6e-5, rtol=6e-5)
 
 
 if __name__ == '__main__':

--- a/benchmark/benchmark_mppt.py
+++ b/benchmark/benchmark_mppt.py
@@ -10,13 +10,13 @@ import pickle
 
 import numpy as np
 
-from openmdao.api import Problem, Group, ParallelGroup, ExplicitComponent, IndepVarComp, \
-    pyOptSparseDriver
+from openmdao.api import Problem, Group, ParallelGroup, IndepVarComp, pyOptSparseDriver
 from openmdao.utils.assert_utils import assert_near_equal
 
 from CADRE.power import Power_SolarPower, Power_CellVoltage
 from CADRE.parameters import BsplineParameters
 import CADRE.test
+from CADRE.explicit import ExplicitComponent
 
 
 class Perf(ExplicitComponent):

--- a/examples/mppt.py
+++ b/examples/mppt.py
@@ -8,13 +8,13 @@ import pickle
 
 import numpy as np
 
-from openmdao.api import Problem, Group, ParallelGroup, IndepVarComp, ExplicitComponent
+from openmdao.api import Problem, Group, ParallelGroup, IndepVarComp
 from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 
 from CADRE.power import Power_SolarPower, Power_CellVoltage
 from CADRE.parameters import BsplineParameters
 import CADRE.test
-
+from CADRE.explicit import ExplicitComponent
 
 class Perf(ExplicitComponent):
 


### PR DESCRIPTION
CADRE depends on components being allowed to be both matrix free and jacobian based at the same time, so gave CADRE a custom ExplicitComponent class that exhibits that behavior, which is no longer supported in OpenMDAO.