### PR TITLE
Update test to handle change in OpenMDAO 3.38.1-dev

### DIFF
--- a/CADRE/test/test_mdp.py
+++ b/CADRE/test/test_mdp.py
@@ -92,20 +92,16 @@ class TestCADRE(unittest.TestCase):
             resolver = model._resolver
 
             def get_abs_name(prom_name):
-                print(f"prom_name: {prom_name} -> {resolver.prom2abs(prom_name, 'output')}")
-                return resolver.prom2abs(prom_name, 'output')
+                return resolver.prom2abs(prom_name)
 
             def get_prom_name(abs_name):
-                print(f"abs_name: {abs_name} -> {resolver.abs2prom(abs_name, 'output')}")
-                return resolver.prom2abs(abs_name, 'output')
+                return resolver.abs2prom(abs_name)
 
         except AttributeError:
             def get_abs_name(prom_name):
-                print(f"prom_name: {prom_name} -> {model._var_allprocs_prom2abs_list['output'][prom_name][0]}")
                 return model._var_allprocs_prom2abs_list['output'][prom_name][0]
 
             def get_prom_name(abs_name):
-                print(f"abs_name: {abs_name} -> {model._var_allprocs_abs2prom['output'][abs_name]}")
                 return model._var_allprocs_abs2prom['output'][abs_name]
 
         # check output values
@@ -193,9 +189,7 @@ class TestCADRE(unittest.TestCase):
                     # as of OpenMDAO 3.31.0, the keys in the jac are the 'user facing' names
                     # given to the design vars and responses, rather than the absolute names
                     # that were used previously
-                    prom_bkey1 = get_prom_name(bkey1)
-                    prom_bkey2 = get_prom_name(bkey2)
-                    computed = Jb[prom_bkey1, prom_bkey2]
+                    computed = Jb[get_prom_name(bkey1), get_prom_name(bkey2)]
 
                 if isinstance(computed, np.ndarray):
                     rel = np.linalg.norm(actual - computed)/np.linalg.norm(actual)

--- a/CADRE/test/test_mdp.py
+++ b/CADRE/test/test_mdp.py
@@ -87,9 +87,28 @@ class TestCADRE(unittest.TestCase):
         prob.setup(check=verbose)
         prob.run_driver()
 
-        # check output values
-        abs_names = model._var_allprocs_prom2abs_list['output']
+        # a change in OpenMDAO 3.38.1-dev adds a resolver in place of the prom2abs/abs2prom attributes
+        try:
+            resolver = model._resolver
 
+            def get_abs_name(prom_name):
+                print(f"prom_name: {prom_name} -> {resolver.prom2abs(prom_name, 'output')}")
+                return resolver.prom2abs(prom_name, 'output')
+
+            def get_prom_name(abs_name):
+                print(f"abs_name: {abs_name} -> {resolver.abs2prom(abs_name, 'output')}")
+                return resolver.prom2abs(abs_name, 'output')
+
+        except AttributeError:
+            def get_abs_name(prom_name):
+                print(f"prom_name: {prom_name} -> {model._var_allprocs_prom2abs_list['output'][prom_name][0]}")
+                return model._var_allprocs_prom2abs_list['output'][prom_name][0]
+
+            def get_prom_name(abs_name):
+                print(f"abs_name: {abs_name} -> {model._var_allprocs_abs2prom['output'][abs_name]}")
+                return model._var_allprocs_abs2prom['output'][abs_name]
+
+        # check output values
         checked = 0
 
         for var in data:
@@ -105,7 +124,7 @@ class TestCADRE(unittest.TestCase):
                 xvar = xvar.replace('_con4.val', '.ConS1')
 
             # make sure var is local before we try to look it up
-            compname = abs_names[xvar][0].rsplit('.', 1)[0]
+            compname = get_abs_name(xvar).rsplit('.', 1)[0]
             comp = model._get_subsystem(compname)
             if comp and not (comp.comm is None or comp.comm == MPI.COMM_NULL):
                 computed = prob[xvar]
@@ -174,8 +193,9 @@ class TestCADRE(unittest.TestCase):
                     # as of OpenMDAO 3.31.0, the keys in the jac are the 'user facing' names
                     # given to the design vars and responses, rather than the absolute names
                     # that were used previously
-                    computed = Jb[prob.model._var_allprocs_abs2prom['output'][bkey1],
-                                  prob.model._var_allprocs_abs2prom['output'][bkey2]]
+                    prom_bkey1 = get_prom_name(bkey1)
+                    prom_bkey2 = get_prom_name(bkey2)
+                    computed = Jb[prom_bkey1, prom_bkey2]
 
                 if isinstance(computed, np.ndarray):
                     rel = np.linalg.norm(actual - computed)/np.linalg.norm(actual)

--- a/CADRE/test/test_mdp.py
+++ b/CADRE/test/test_mdp.py
@@ -92,10 +92,10 @@ class TestCADRE(unittest.TestCase):
             resolver = model._resolver
 
             def get_abs_name(prom_name):
-                return resolver.prom2abs(prom_name)
+                return resolver.prom2abs(prom_name, 'output')
 
             def get_prom_name(abs_name):
-                return resolver.abs2prom(abs_name)
+                return resolver.abs2prom(abs_name, 'output')
 
         except AttributeError:
             def get_abs_name(prom_name):


### PR DESCRIPTION
The MDP test used the private prom2abs and abs2prom attributes on the model.  These dictionaries have been replaced with a new name resolver in OpenMDAO  [3.38.1-dev](https://github.com/OpenMDAO/OpenMDAO/pull/3512).  The test has been updated to use the name resolver if available.