### PR TITLE
Updated CADRE ExplicitComponent to handle change in _linearize

### DIFF
--- a/CADRE/explicit.py
+++ b/CADRE/explicit.py
@@ -1,4 +1,6 @@
 
+from openmdao import __version__ as om_version
+
 from openmdao.core.explicitcomponent import ExplicitComponent as om_ExplicitComponent
 
 class ExplicitComponent(om_ExplicitComponent):
@@ -18,6 +20,9 @@ class ExplicitComponent(om_ExplicitComponent):
         save = self.matrix_free
         self.matrix_free = False
         try:
-            super()._linearize(jac, sub_do_ln)
+            if om_version >= '3.39.0':
+                super()._linearize(sub_do_ln)
+            else:
+                super()._linearize(jac, sub_do_ln)
         finally:
             self.matrix_free = save

--- a/CADRE/explicit.py
+++ b/CADRE/explicit.py
@@ -20,7 +20,7 @@ class ExplicitComponent(om_ExplicitComponent):
         save = self.matrix_free
         self.matrix_free = False
         try:
-            if om_version >= '3.39.0':
+            if om_version > '3.39.0':
                 super()._linearize(sub_do_ln)
             else:
                 super()._linearize(jac, sub_do_ln)


### PR DESCRIPTION
A recent OpenMDAO refactor in https://github.com/OpenMDAO/OpenMDAO/pull/3552 changes the function signature for `ExplicitComponent._linearize()`.

This updates the CADRE version of `ExplicitComponent` to handle the change.